### PR TITLE
Improve key matching and default column naming

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,1 @@
-source_up
 use flake

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,6 @@
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [
             rustToolchain
-            rust-analyzer
           ];
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -19,9 +19,24 @@
           overlays = [(import rust-overlay)];
         };
         rustToolchain = pkgs.rust-bin.stable.latest.default.override {
-          extensions = ["rust-src" "rustfmt" "clippy"];
+          extensions = ["rust-src" "rustfmt" "clippy" "rust-analyzer"];
         };
+
+        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+
+        pname = cargoToml.package.name;
+        version = cargoToml.package.version;
       in {
+        packages = rec {
+          default = nvmbuilder;
+          nvmbuilder = pkgs.rustPlatform.buildRustPackage {
+            inherit pname version;
+            src = ./.;
+            cargoLock.lockFile = ./Cargo.lock;
+            buildType = "release";
+          };
+        };
+
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [
             rustToolchain

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -25,7 +25,7 @@ fn calculate_crc(bytestream: &[u8], crc_settings: &CrcData) -> u32 {
 
     let crc_calc = Crc::<u32>::new(algo_static);
     let mut crc_digest = crc_calc.digest();
-    crc_digest.update(&bytestream);
+    crc_digest.update(bytestream);
     crc_digest.finalize()
 }
 
@@ -91,7 +91,7 @@ pub fn bytestream_to_hex_string(
     bytestream.resize(header.length as usize, header.padding);
     bytestream[crc_offset as usize..(crc_offset + 4) as usize].copy_from_slice(&crc_bytes);
 
-    let hex_string = emit_hex(header.start_address + offset, &bytestream)?;
+    let hex_string = emit_hex(header.start_address + offset, bytestream)?;
     Ok(hex_string)
 }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -137,11 +137,9 @@ impl LeafEntry {
 
                 Ok(out)
             }
-            EntrySource::Value(_) => {
-                return Err(NvmError::DataValueExportFailed(
-                    "2D arrays within the layout file are not supported.".to_string(),
-                ));
-            }
+            EntrySource::Value(_) => Err(NvmError::DataValueExportFailed(
+                "2D arrays within the layout file are not supported.".to_string(),
+            )),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn build_block(
         .get(block_name)
         .ok_or(NvmError::BlockNotFound(block_name.to_string()))?;
 
-    let mut bytestream = block.build_bytestream(&data_sheet, &layout.settings)?;
+    let mut bytestream = block.build_bytestream(data_sheet, &layout.settings)?;
 
     let hex_string = bytestream_to_hex_string(
         &mut bytestream,

--- a/src/variants.rs
+++ b/src/variants.rs
@@ -6,6 +6,8 @@ use crate::schema::*;
 
 pub struct DataSheet {
     names: Vec<String>,
+    // Lowercased name -> index for case-insensitive lookup from layout to Excel
+    names_lower_to_index: HashMap<String, usize>,
     default_values: Vec<Data>,
     debug_values: Option<Vec<Data>>,
     variant_values: Option<Vec<Data>>,
@@ -36,13 +38,21 @@ impl DataSheet {
             .position(|cell| Self::cell_eq_ascii(cell, "Name"))
             .ok_or(NvmError::ColumnNotFound("Name".to_string()))?;
 
+        // Allow a few aliases for the default column, case-insensitive
+        let default_aliases = ["Default", "Defaults", "Generic"];
         let default_index = headers
             .iter()
-            .position(|cell| Self::cell_eq_ascii(cell, "Default"))
+            .position(|cell| default_aliases.iter().any(|opt| Self::cell_eq_ascii(cell, opt)))
             .ok_or(NvmError::ColumnNotFound("Default".to_string()))?;
 
         let mut names: Vec<String> = Vec::with_capacity(data_rows);
         names.extend(rows.iter().skip(1).map(|row| row[name_index].to_string()));
+
+        // Build a lowercase name -> index map for case-insensitive lookups
+        let mut names_lower_to_index: HashMap<String, usize> = HashMap::with_capacity(names.len());
+        for (idx, nm) in names.iter().enumerate() {
+            names_lower_to_index.insert(nm.trim().to_ascii_lowercase(), idx);
+        }
 
         let mut default_values: Vec<Data> = Vec::with_capacity(data_rows);
         default_values.extend(rows.iter().skip(1).map(|row| row[default_index].clone()));
@@ -64,7 +74,7 @@ impl DataSheet {
         if let Some(name) = variant {
             let variant_index = headers
                 .iter()
-                .position(|cell| cell.to_string() == *name)
+                .position(|cell| Self::cell_eq_ascii(cell, name))
                 .ok_or(NvmError::ColumnNotFound(name.to_string()))?;
 
             let mut variant_vec: Vec<Data> = Vec::with_capacity(data_rows);
@@ -83,6 +93,7 @@ impl DataSheet {
 
         Ok(Self {
             names,
+            names_lower_to_index,
             default_values,
             debug_values,
             variant_values,
@@ -192,10 +203,10 @@ impl DataSheet {
     }
 
     fn retrieve_cell(&self, name: &str) -> Result<&Data, NvmError> {
-        let index = self
-            .names
-            .iter()
-            .position(|n| n == name)
+        let key = name.trim().to_ascii_lowercase();
+        let index = *self
+            .names_lower_to_index
+            .get(&key)
             .ok_or(NvmError::RetrievalError(
                 "index not found for ".to_string() + name,
             ))?;


### PR DESCRIPTION
Make layout key matching to Excel, default column aliases, and variant column headers case-insensitive to provide more lenient naming.

---
<a href="https://cursor.com/background-agent?bcId=bc-66e9d89d-3603-4b5d-8441-4a77b62aaa0c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-66e9d89d-3603-4b5d-8441-4a77b62aaa0c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

