### PR TITLE
Add optional prefix and suffix args

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Build flash blocks from a layout file (TOML/YAML/JSON) and an Excel workbook, th
 ### Usage
 
 ```bash
-nvmbuilder <BLOCK>... -l <LAYOUT> -x <XLSX> [-v <VARIANT>] [-d] [-o <DIR>] [--offset <OFFSET>]
+nvmbuilder <BLOCK>... -l <LAYOUT> -x <XLSX> \
+  [-v <VARIANT>] [-d] [-o <DIR>] [--offset <OFFSET>] \
+  [--prefix <STR>] [--suffix <STR>]
 ```
 
 - **BLOCK**: one or more block names to build (positional)
@@ -15,6 +17,8 @@ nvmbuilder <BLOCK>... -l <LAYOUT> -x <XLSX> [-v <VARIANT>] [-d] [-o <DIR>] [--of
 - **-d, --debug**: prefer the Debug column when present (optional)
 - **-o, --out DIR**: output directory for `.hex` files (default: `out`)
 - **--offset OFFSET**: Optional u32 virtual address offset (hex or dec)
+- **--prefix STR**: Optional string prepended to block name in output filename
+- **--suffix STR**: Optional string appended to block name in output filename
 
 The order of preference for value selection is debug -> variant -> default. Ensure you always have default filled. Strings in the excel can point to different sheets as a way of providing arrays.
 
@@ -34,6 +38,6 @@ nvmbuilder block -l examples/block.yaml -x examples/data.xlsx -o out --offset 0x
 nvmbuilder block -l examples/block.json -x examples/data.xlsx -o out
 ```
 
-Outputs are written to the chosen directory as `{block}.hex`.
+Outputs are written to the chosen directory as `{prefix}{block}{suffix}.hex`.
 
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ nvmbuilder block -l examples/block.yaml -x examples/data.xlsx -o out --offset 0x
 nvmbuilder block -l examples/block.json -x examples/data.xlsx -o out
 ```
 
-Outputs are written to the chosen directory as `{prefix}{block}{suffix}.hex`.
+Outputs are written to the chosen directory as `{prefix}_{block}_{suffix}.hex`, omitting empty parts and their underscores. Examples: `block.hex`, `PRE_block.hex`, `block_SUF.hex`, `PRE_block_SUF.hex`.
 
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -73,4 +73,20 @@ pub struct Args {
         help = "Optional virtual address offset (hex or dec)"
     )]
     pub offset: u32,
+
+    #[arg(
+        long,
+        value_name = "STR",
+        default_value = "",
+        help = "Optional prefix to prepend to each block name in output filename"
+    )]
+    pub prefix: String,
+
+    #[arg(
+        long,
+        value_name = "STR",
+        default_value = "",
+        help = "Optional suffix to append to each block name in output filename"
+    )]
+    pub suffix: String,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,15 @@ fn build_block(
         args.byte_swap,
     )?;
 
-    let out_filename = format!("{}{}{}.hex", args.prefix, block_name, args.suffix);
+    let mut name_parts: Vec<String> = Vec::new();
+    if !args.prefix.is_empty() {
+        name_parts.push(args.prefix.clone());
+    }
+    name_parts.push(block_name.to_string());
+    if !args.suffix.is_empty() {
+        name_parts.push(args.suffix.clone());
+    }
+    let out_filename = format!("{}.hex", name_parts.join("_"));
     let out_path = Path::new(&args.out).join(out_filename);
     std::fs::write(out_path, hex_string)
         .map_err(|e| NvmError::FileError(format!("failed to write block {}: {}", block_name, e)))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,8 @@ fn build_block(
         args.byte_swap,
     )?;
 
-    let out_path = Path::new(&args.out).join(format!("{}.hex", block_name));
+    let out_filename = format!("{}{}{}.hex", args.prefix, block_name, args.suffix);
+    let out_path = Path::new(&args.out).join(out_filename);
     std::fs::write(out_path, hex_string)
         .map_err(|e| NvmError::FileError(format!("failed to write block {}: {}", block_name, e)))?;
 
@@ -127,6 +128,8 @@ mod tests {
                             out: "out".to_string(),
                             offset: off,
                             main_sheet: "Main".to_string(),
+                            prefix: "".to_string(),
+                            suffix: "".to_string(),
                         },
                     )
                     .expect("build_block failed");


### PR DESCRIPTION
Add optional `--prefix` and `--suffix` CLI arguments to customize output hex filenames.

---
Linear Issue: [PER-11](https://linear.app/tomfordpersonal/issue/PER-11/add-prefix-and-suffix-optional-args)

<a href="https://cursor.com/background-agent?bcId=bc-4d50c2e3-7c3b-410e-bb55-6850186b8ee8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4d50c2e3-7c3b-410e-bb55-6850186b8ee8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

