### PR TITLE
Add --pad-to-end cli flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Build flash blocks from a layout file (TOML/YAML/JSON) and an Excel workbook, th
 ```bash
 nvmbuilder <BLOCK>... -l <LAYOUT> -x <XLSX> \
   [-v <VARIANT>] [-d] [-o <DIR>] [--offset <OFFSET>] \
-  [--prefix <STR>] [--suffix <STR>] [--record-width N]
+  [--prefix <STR>] [--suffix <STR>] [--record-width N] [--pad-to-end]
 
 ```
 
@@ -21,6 +21,7 @@ nvmbuilder <BLOCK>... -l <LAYOUT> -x <XLSX> \
 - **--prefix STR**: Optional string prepended to block name in output filename
 - **--suffix STR**: Optional string appended to block name in output filename
 - **--record-width N**: number of bytes per HEX data record (default: 32; range 1..=64)
+ - **--pad-to-end**: pad the output HEX to the full block length (default: off)
 
 The order of preference for value selection is debug -> variant -> default. Ensure you always have default filled. Strings in the excel can point to different sheets as a way of providing arrays.
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -98,4 +98,7 @@ pub struct Args {
         help = "Number of bytes per HEX data record (1..=64)"
     )]
     pub record_width: u16,
+
+    #[arg(long, help = "Pad output HEX to the full block length")]
+    pub pad_to_end: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ fn build_block(
         args.offset,
         args.byte_swap,
         args.record_width as usize,
+        args.pad_to_end,
     )?;
 
     let mut name_parts: Vec<String> = Vec::new();
@@ -140,6 +141,7 @@ mod tests {
                             prefix: "PRE".to_string(),
                             suffix: "SUF".to_string(),
                             record_width: 32,
+                            pad_to_end: false,
                         },
                     )
                     .expect("build_block failed");


### PR DESCRIPTION
Add `--pad-to-end` CLI flag to optionally pad the output HEX to the full block length, making minimal padding the new default.

---
Linear Issue: [LIN-14](https://linear.app/tomfordpersonal/issue/LIN-14/add-option-for-padding-the-full-block)

<a href="https://cursor.com/background-agent?bcId=bc-21fa40f4-3f45-48fa-b363-10e916611645">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-21fa40f4-3f45-48fa-b363-10e916611645">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

