### PR TITLE
Add ast-grep and document its usage

### DIFF
--- a/.cursor/rules/project-overview.mdc
+++ b/.cursor/rules/project-overview.mdc
@@ -1,4 +1,0 @@
----
-alwaysApply: true
----
-The goal nvmbuilder is to make an executable capable of parsing both a toml/yaml/json file and excel spreadsheet, combining the data together to generate a bytestream and then write an intel hex file that can be flashed to embedded microcontrollers. The layout, adresses, endianness and other settings are defined in the toml file, and the excel stores numerical values and platform variations for the data structure that we are assembling.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS Overview
+
+This document houses the canonical "Overview" rule text for project agents.
+
+> Placeholder: The "overview" rule content was not found in this repository when this file was created. Paste the authoritative Overview rule text here.
+
+---
+
+## Note: ast-grep is available in the dev shell
+
+`ast-grep` from nixpkgs is installed in the Nix dev shell. Use it for semantic code search and safe, rule-driven refactors.
+
+- Quick check: `nix develop -c ast-grep --version | cat`
+- Example scan: `ast-grep scan -p 'fn main' .`
+
+Prefer codifying changes as ast-grep rules before sweeping edits to keep refactors reproducible.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,9 @@
 # AGENTS Overview
 
-This document houses the canonical "Overview" rule text for project agents.
-
-> Placeholder: The "overview" rule content was not found in this repository when this file was created. Paste the authoritative Overview rule text here.
+Nvmbuilder is an embedded development tool that works with layout files (toml/yaml/json) and excel sheets to assemble, diff, export, sign (and more) static hex files for flashing to microcontrollers.
 
 ---
 
-## Note: ast-grep is available in the dev shell
+## Tools
 
-`ast-grep` from nixpkgs is installed in the Nix dev shell. Use it for semantic code search and safe, rule-driven refactors.
-
-- Quick check: `nix develop -c ast-grep --version | cat`
-- Example scan: `ast-grep scan -p 'fn main' .`
-
-Prefer codifying changes as ast-grep rules before sweeping edits to keep refactors reproducible.
-
+use `ast-grep` for semantic code search and better refactoring. Prefer codifying changes as ast-grep rules before sweeping edits to keep refactors reproducible.

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [
             rustToolchain
+            ast-grep
           ];
         };
       }


### PR DESCRIPTION
Add `ast-grep` to the Nix dev shell and create `AGENTS.md` to house agent overview rules (with a placeholder) and document `ast-grep` usage.

---
<a href="https://cursor.com/background-agent?bcId=bc-0d9a5ef5-e023-4d7d-a5cc-306cd471e15b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0d9a5ef5-e023-4d7d-a5cc-306cd471e15b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

