### PR TITLE
Integrate offset into layout file parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Build flash blocks from a layout file (TOML/YAML/JSON) and an Excel workbook, th
 
 ```bash
 nvmbuilder <BLOCK>... -l <LAYOUT> -x <XLSX> \
-  [-v <VARIANT>] [-d] [-o <DIR>] [--offset <OFFSET>] \
+  [-v <VARIANT>] [-d] [-o <DIR>] \
   [--prefix <STR>] [--suffix <STR>] [--record-width N] [--pad-to-end]
 
 ```
@@ -17,7 +17,7 @@ nvmbuilder <BLOCK>... -l <LAYOUT> -x <XLSX> \
 - **-v, --variant NAME**: column in the workbook to use for variants (optional)
 - **-d, --debug**: prefer the Debug column when present (optional)
 - **-o, --out DIR**: output directory for `.hex` files (default: `out`)
-- **--offset OFFSET**: Optional u32 virtual address offset (hex or dec)
+- Offset is now configured in the layout file as a top-level `offset` field (hex like `0x8000` or decimal). The CLI `--offset` flag has been removed.
 - **--prefix STR**: Optional string prepended to block name in output filename
 - **--suffix STR**: Optional string appended to block name in output filename
 - **--record-width N**: number of bytes per HEX data record (default: 32; range 1..=64)
@@ -37,7 +37,7 @@ nvmbuilder block -l examples/block.toml -x examples/data.xlsx -o out
 nvmbuilder blockA blockB -l examples/block.toml -x examples/data.xlsx -v VarA -d -o out
 
 # Using YAML or JSON layouts
-nvmbuilder block -l examples/block.yaml -x examples/data.xlsx -o out --offset 0x10000
+nvmbuilder block -l examples/block.yaml -x examples/data.xlsx -o out
 nvmbuilder block -l examples/block.json -x examples/data.xlsx -o out
 ```
 

--- a/examples/block.json
+++ b/examples/block.json
@@ -1,4 +1,5 @@
 {
+    "offset": 0,
     "settings": {
         "endianness": "little",
         "crc": {

--- a/examples/block.toml
+++ b/examples/block.toml
@@ -1,3 +1,5 @@
+offset = 0x0
+
 [settings]
 endianness = "little"
 

--- a/examples/block.yaml
+++ b/examples/block.yaml
@@ -1,3 +1,5 @@
+offset: 0
+
 settings:
   endianness: "little"
   crc:

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,11 +1,17 @@
 use crate::error::*;
 use indexmap::IndexMap;
-use serde::Deserialize;
+use serde::{de, Deserialize, Deserializer};
+use std::fmt;
 
 /// Top level struct that contains the settings and the block.
 #[derive(Debug, Deserialize)]
 pub struct Config {
     pub settings: Settings,
+    #[serde(
+        default = "default_offset",
+        deserialize_with = "deserialize_u32_from_str_or_int"
+    )]
+    pub offset: u32,
     #[serde(flatten)]
     pub blocks: IndexMap<String, Block>,
 }
@@ -62,6 +68,74 @@ pub struct Header {
 /// Function to provide a default padding value.
 fn default_padding() -> u8 {
     0xFF
+}
+
+fn default_offset() -> u32 {
+    0
+}
+
+fn parse_u32_from_str(offset: &str) -> Result<u32, ()> {
+    let s = offset.trim();
+    let (radix, digits) = if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        (16, hex)
+    } else {
+        (10, s)
+    };
+
+    u32::from_str_radix(&digits.replace('_', ""), radix).map_err(|_| ())
+}
+
+pub fn deserialize_u32_from_str_or_int<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct U32Visitor;
+
+    impl<'de> de::Visitor<'de> for U32Visitor {
+        type Value = u32;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "a u32 or a string containing a hex (0x...) or decimal number")
+        }
+
+        fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            u32::try_from(v).map_err(|_| E::custom("Offset value out of range for u32."))
+        }
+
+        fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            if v < 0 {
+                return Err(E::custom("Offset must be a non-negative number."));
+            }
+            u32::try_from(v as u64).map_err(|_| E::custom("Offset value out of range for u32."))
+        }
+
+        fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            parse_u32_from_str(s).map_err(|_| {
+                E::custom(format!(
+                    "Invalid offset value '{}' in layout file. Must be valid hexadecimal or decimal address.",
+                    s
+                ))
+            })
+        }
+
+        fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            self.visit_str(&s)
+        }
+    }
+
+    deserializer.deserialize_any(U32Visitor)
 }
 
 /// Any entry - should always be either a leaf or a branch (more entries).
@@ -224,3 +298,58 @@ macro_rules! impl_try_from_data_value {
     )* }; }
 
 impl_try_from_data_value!(u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_toml_with_offset(offset_line: &str) -> String {
+        format!(
+            r#"{offset}
+[settings]
+endianness = "little"
+
+[settings.crc]
+polynomial = 0x04C11DB7
+start = 0xFFFFFFFF
+xor_out = 0xFFFFFFFF
+ref_in = true
+ref_out = true
+
+[block.header]
+start_address = 0x1000
+length = 0x20
+crc_location = "end"
+
+[block.data]
+item = {{ value = 1, type = "u8" }}
+"#,
+            offset = offset_line
+        )
+    }
+
+    #[test]
+    fn parses_offset_hex_and_decimal() {
+        let toml_hex = minimal_toml_with_offset("offset = 0x8000");
+        let cfg_hex: Config = toml::from_str(&toml_hex).expect("parse hex offset");
+        assert_eq!(cfg_hex.offset, 0x8000);
+
+        let toml_dec = minimal_toml_with_offset("offset = 4096");
+        let cfg_dec: Config = toml::from_str(&toml_dec).expect("parse dec offset");
+        assert_eq!(cfg_dec.offset, 4096);
+    }
+
+    #[test]
+    fn missing_offset_defaults_to_zero() {
+        let toml_no = minimal_toml_with_offset("");
+        let cfg: Config = toml::from_str(&toml_no).expect("parse without offset");
+        assert_eq!(cfg.offset, 0);
+    }
+
+    #[test]
+    fn invalid_offset_reports_helpful_error() {
+        let toml_bad = minimal_toml_with_offset("offset = '0xGGGG'");
+        let err = toml::from_str::<Config>(&toml_bad).unwrap_err().to_string();
+        assert!(err.contains("Invalid offset value"));
+    }
+}


### PR DESCRIPTION
Replace the `--offset` CLI flag with a top-level `offset` parameter in the layout file to improve build reproducibility and reduce CLI complexity.

---
Linear Issue: [LIN-28](https://linear.app/tomfordpersonal/issue/LIN-28/replace-offset-cli-flag-with-layout-file-parameter)

<a href="https://cursor.com/background-agent?bcId=bc-63878207-9a9e-4047-b22d-36620dd970dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63878207-9a9e-4047-b22d-36620dd970dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

