### PR TITLE
Implement strict type conversions with try_from_strict

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -5,28 +5,32 @@ use crate::layout::args::BlockNames;
 use crate::variant::DataSheet;
 use crate::writer::write_output;
 
-pub fn build_block_single(input: &BlockNames, data_sheet: &DataSheet, args: &Args) -> Result<(), NvmError> {
-	let layout = layout::load_layout(&input.file)?;
+pub fn build_block_single(
+    input: &BlockNames,
+    data_sheet: &DataSheet,
+    args: &Args,
+) -> Result<(), NvmError> {
+    let layout = layout::load_layout(&input.file)?;
 
-	let block = layout
-		.blocks
-		.get(&input.name)
-		.ok_or(NvmError::BlockNotFound(input.name.clone()))?;
+    let block = layout
+        .blocks
+        .get(&input.name)
+        .ok_or(NvmError::BlockNotFound(input.name.clone()))?;
 
-	let mut bytestream = block.build_bytestream(data_sheet, &layout.settings)?;
+    let mut bytestream =
+        block.build_bytestream(data_sheet, &layout.settings, args.layout.strict)?;
 
-	let hex_string = crate::output::bytestream_to_hex_string(
-		&mut bytestream,
-		&block.header,
-		&layout.settings,
-		layout.settings.byte_swap,
-		args.output.record_width as usize,
-		layout.settings.pad_to_end,
-		args.output.format,
-	)?;
+    let hex_string = crate::output::bytestream_to_hex_string(
+        &mut bytestream,
+        &block.header,
+        &layout.settings,
+        layout.settings.byte_swap,
+        args.output.record_width as usize,
+        layout.settings.pad_to_end,
+        args.output.format,
+    )?;
 
-	write_output(&args.output, &input.name, &hex_string)?;
+    write_output(&args.output, &input.name, &hex_string)?;
 
-	Ok(())
+    Ok(())
 }
-

--- a/src/layout/args.rs
+++ b/src/layout/args.rs
@@ -27,4 +27,11 @@ pub fn parse_block_arg(block: &str) -> Result<BlockNames, NvmError> {
 pub struct LayoutArgs {
     #[arg(value_name = "BLOCK@FILE", num_args = 1.., value_parser = parse_block_arg, help = "One or more blocks in the form name@layout_file (toml/yaml/json)")]
     pub blocks: Vec<BlockNames>,
+
+    #[arg(
+        long,
+        help = "Enable strict type conversions; disallow lossy casts during bytestream assembly",
+        default_value_t = false
+    )]
+    pub strict: bool,
 }

--- a/src/layout/block.rs
+++ b/src/layout/block.rs
@@ -34,6 +34,7 @@ impl Block {
         &self,
         data_sheet: &DataSheet,
         settings: &Settings,
+        strict: bool,
     ) -> Result<Vec<u8>, NvmError> {
         let mut buffer = Vec::with_capacity(self.header.length as usize);
         let mut offset = 0;
@@ -45,6 +46,7 @@ impl Block {
             &mut offset,
             &settings.endianness,
             &self.header.padding,
+            strict,
         )?;
 
         if matches!(self.header.crc_location, CrcLocation::Keyword(_)) {
@@ -65,6 +67,7 @@ impl Block {
         offset: &mut usize,
         endianness: &Endianness,
         padding: &u8,
+        strict: bool,
     ) -> Result<(), NvmError> {
         match table {
             Entry::Leaf(leaf) => {
@@ -74,14 +77,14 @@ impl Block {
                     *offset += 1;
                 }
 
-                let bytes = leaf.emit_bytes(data_sheet, endianness, padding)?;
+                let bytes = leaf.emit_bytes(data_sheet, endianness, padding, strict)?;
                 *offset += bytes.len();
                 buffer.extend(bytes);
             }
             Entry::Branch(branch) => {
                 for (_, v) in branch.iter() {
                     Self::build_bytestream_inner(
-                        v, data_sheet, buffer, offset, endianness, padding,
+                        v, data_sheet, buffer, offset, endianness, padding, strict,
                     )?;
                 }
             }

--- a/src/layout/conversions.rs
+++ b/src/layout/conversions.rs
@@ -1,3 +1,5 @@
+use super::entry::ScalarType;
+use super::settings::{EndianBytes, Endianness};
 use super::value::DataValue;
 use crate::error::*;
 
@@ -21,3 +23,139 @@ macro_rules! impl_try_from_data_value {
     )* }; }
 
 impl_try_from_data_value!(u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
+
+pub trait TryFromStrict<T>: Sized {
+    fn try_from_strict(value: T) -> Result<Self, NvmError>;
+}
+
+macro_rules! err {
+    ($msg:expr) => {
+        NvmError::DataValueExportFailed($msg.to_string())
+    };
+}
+
+macro_rules! impl_try_from_strict_unsigned {
+    ($($t:ty),* $(,)?) => {$({
+        impl TryFromStrict<&DataValue> for $t {
+            fn try_from_strict(value: &DataValue) -> Result<Self, NvmError> {
+                match value {
+                    DataValue::U64(v) => <Self as TryFrom<u64>>::try_from(*v)
+                        .map_err(|_| err!(format!("u64 value {} out of range for {}", v, stringify!($t)))),
+                    DataValue::I64(v) => {
+                        if *v < 0 { return Err(err!("negative integer cannot convert to unsigned in strict mode")); }
+                        <Self as TryFrom<u64>>::try_from(*v as u64)
+                            .map_err(|_| err!(format!("i64 value {} out of range for {}", v, stringify!($t))))
+                    }
+                    DataValue::F64(v) => {
+                        if !v.is_finite() { return Err(err!("non-finite float cannot convert to integer in strict mode")); }
+                        if v.fract() != 0.0 { return Err(err!("float to integer conversion not allowed unless value is an exact integer")); }
+                        if *v < 0.0 || *v > (<$t>::MAX as f64) { return Err(err!(format!("float value {} out of range for {}", v, stringify!($t)))); }
+                        Ok(*v as $t)
+                    }
+                    DataValue::Str(_) => Err(err!("Cannot convert string to scalar type.")),
+                }
+            }
+        }
+    })*};
+}
+
+macro_rules! impl_try_from_strict_signed {
+    ($($t:ty),* $(,)?) => {$({
+        impl TryFromStrict<&DataValue> for $t {
+            fn try_from_strict(value: &DataValue) -> Result<Self, NvmError> {
+                match value {
+                    DataValue::U64(v) => {
+                        <Self as TryFrom<i128>>::try_from(*v as i128)
+                            .map_err(|_| err!(format!("u64 value {} out of range for {}", v, stringify!($t))))
+                    }
+                    DataValue::I64(v) => <Self as TryFrom<i64>>::try_from(*v)
+                        .map_err(|_| err!(format!("i64 value {} out of range for {}", v, stringify!($t)))),
+                    DataValue::F64(v) => {
+                        if !v.is_finite() { return Err(err!("non-finite float cannot convert to integer in strict mode")); }
+                        if v.fract() != 0.0 { return Err(err!("float to integer conversion not allowed unless value is an exact integer")); }
+                        if *v < (<$t>::MIN as f64) || *v > (<$t>::MAX as f64) { return Err(err!(format!("float value {} out of range for {}", v, stringify!($t)))); }
+                        Ok(*v as $t)
+                    }
+                    DataValue::Str(_) => Err(err!("Cannot convert string to scalar type.")),
+                }
+            }
+        }
+    })*};
+}
+
+macro_rules! impl_try_from_strict_float_targets {
+    ($t:ty) => {
+        impl TryFromStrict<&DataValue> for $t {
+            fn try_from_strict(value: &DataValue) -> Result<Self, NvmError> {
+                match value {
+                    DataValue::F64(v) => {
+                        let out = *v as $t;
+                        if !v.is_finite() || !out.is_finite() {
+                            return Err(err!("non-finite float not allowed in strict mode"));
+                        }
+                        if (out as f64) == *v { Ok(out) } else { Err(err!("lossy float narrowing conversion not allowed in strict mode")) }
+                    }
+                    DataValue::U64(v) => {
+                        let out = (*v as $t);
+                        if !out.is_finite() { return Err(err!("integer to float produced non-finite value")); }
+                        // exactness check via round-trip
+                        if (out as u64) == *v { Ok(out) } else { Err(err!("lossy integer to float conversion not allowed in strict mode")) }
+                    }
+                    DataValue::I64(v) => {
+                        let out = (*v as $t);
+                        if !out.is_finite() { return Err(err!("integer to float produced non-finite value")); }
+                        if (out as i64) == *v { Ok(out) } else { Err(err!("lossy integer to float conversion not allowed in strict mode")) }
+                    }
+                    DataValue::Str(_) => Err(err!("Cannot convert string to scalar type.")),
+                }
+            }
+        }
+    }
+}
+
+impl_try_from_strict_unsigned!(u8, u16, u32, u64);
+impl_try_from_strict_signed!(i8, i16, i32, i64);
+impl_try_from_strict_float_targets!(f32);
+impl TryFromStrict<&DataValue> for f64 {
+    fn try_from_strict(value: &DataValue) -> Result<Self, NvmError> {
+        match value {
+            DataValue::F64(v) => Ok(*v),
+            DataValue::U64(v) => {
+                let out = *v as f64;
+                if (out as u64) == *v { Ok(out) } else { Err(err!("lossy integer to float conversion not allowed in strict mode")) }
+            }
+            DataValue::I64(v) => {
+                let out = *v as f64;
+                if (out as i64) == *v { Ok(out) } else { Err(err!("lossy integer to float conversion not allowed in strict mode")) }
+            }
+            DataValue::Str(_) => Err(err!("Cannot convert string to scalar type.")),
+        }
+    }
+}
+
+pub fn convert_value_to_bytes(
+    value: &DataValue,
+    scalar_type: ScalarType,
+    endianness: &Endianness,
+    strict: bool,
+) -> Result<Vec<u8>, NvmError> {
+    macro_rules! to_bytes {
+        ($t:ty) => {{
+            let val: $t = if strict { <$t as TryFromStrict<&DataValue>>::try_from_strict(value)? } else { <$t as TryFrom<&DataValue>>::try_from(value)? };
+            Ok(val.to_endian_bytes(endianness))
+        }};
+    }
+
+    match scalar_type {
+        ScalarType::U8 => to_bytes!(u8),
+        ScalarType::I8 => to_bytes!(i8),
+        ScalarType::U16 => to_bytes!(u16),
+        ScalarType::I16 => to_bytes!(i16),
+        ScalarType::U32 => to_bytes!(u32),
+        ScalarType::I32 => to_bytes!(i32),
+        ScalarType::U64 => to_bytes!(u64),
+        ScalarType::I64 => to_bytes!(i64),
+        ScalarType::F32 => to_bytes!(f32),
+        ScalarType::F64 => to_bytes!(f64),
+    }
+}

--- a/src/layout/value.rs
+++ b/src/layout/value.rs
@@ -1,6 +1,6 @@
 use super::entry::ScalarType;
-use super::settings::EndianBytes;
 use super::settings::Endianness;
+use super::conversions::convert_value_to_bytes;
 use crate::error::*;
 use serde::Deserialize;
 
@@ -25,19 +25,9 @@ impl DataValue {
         &self,
         scalar_type: ScalarType,
         endianness: &Endianness,
+        strict: bool,
     ) -> Result<Vec<u8>, NvmError> {
-        match scalar_type {
-            ScalarType::U8 => Ok(u8::try_from(self)?.to_endian_bytes(endianness)),
-            ScalarType::I8 => Ok(i8::try_from(self)?.to_endian_bytes(endianness)),
-            ScalarType::U16 => Ok(u16::try_from(self)?.to_endian_bytes(endianness)),
-            ScalarType::I16 => Ok(i16::try_from(self)?.to_endian_bytes(endianness)),
-            ScalarType::U32 => Ok(u32::try_from(self)?.to_endian_bytes(endianness)),
-            ScalarType::I32 => Ok(i32::try_from(self)?.to_endian_bytes(endianness)),
-            ScalarType::U64 => Ok(u64::try_from(self)?.to_endian_bytes(endianness)),
-            ScalarType::I64 => Ok(i64::try_from(self)?.to_endian_bytes(endianness)),
-            ScalarType::F32 => Ok(f32::try_from(self)?.to_endian_bytes(endianness)),
-            ScalarType::F64 => Ok(f64::try_from(self)?.to_endian_bytes(endianness)),
-        }
+        convert_value_to_bytes(self, scalar_type, endianness, strict)
     }
 
     pub fn string_to_bytes(&self) -> Result<Vec<u8>, NvmError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 mod args;
+mod commands;
 mod error;
 mod layout;
 mod output;
 mod variant;
 mod writer;
-mod commands;
 
 use clap::Parser;
 
@@ -94,6 +94,7 @@ mod tests {
                             name: blk.to_string(),
                             file: layout_path.to_string(),
                         }],
+                        strict: false,
                     },
                     variant: VariantArgs {
                         xlsx: "examples/data.xlsx".to_string(),
@@ -127,6 +128,7 @@ mod tests {
                             name: blk.to_string(),
                             file: layout_path.to_string(),
                         }],
+                        strict: false,
                     },
                     variant: VariantArgs {
                         xlsx: "examples/data.xlsx".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,4 +151,161 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn strict_conversions_success() {
+        use crate::variant::args::VariantArgs;
+        use std::io::Write;
+
+        std::fs::create_dir_all("out").unwrap();
+
+        // Minimal layout with literal values only (no Excel dependency for values)
+        let layout_toml = r#"
+[settings]
+endianness = "little"
+virtual_offset = 0
+byte_swap = false
+pad_to_end = false
+
+[settings.crc]
+polynomial = 0x04C11DB7
+start = 0xFFFFFFFF
+xor_out = 0xFFFFFFFF
+ref_in = true
+ref_out = true
+
+[block.header]
+start_address = 0x80000
+length = 0x100
+crc_location = "end"
+padding = 0x00
+
+[block.data]
+ok.float_exact_to_i16 = { value = 42.0, type = "i16" }
+ok.int_exact_to_f32   = { value = 16777216, type = "f32" }
+"#;
+
+        let path = Path::new("out").join("test_strict_ok.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(layout_toml.as_bytes()).unwrap();
+
+        let cfg = crate::layout::load_layout(path.to_str().unwrap()).expect("parse ok layout");
+        let block = cfg.blocks.get("block").expect("block present");
+
+        // Any DataSheet will do; values are all literals.
+        let var_args = VariantArgs {
+            xlsx: "examples/data.xlsx".to_string(),
+            variant: None,
+            debug: false,
+            main_sheet: "Main".to_string(),
+        };
+        let ds = DataSheet::new(&var_args).expect("datasheet loads");
+
+        // Strict mode should succeed for exact conversions
+        let bytes = block
+            .build_bytestream(&ds, &cfg.settings, true)
+            .expect("strict conversions should succeed");
+        assert!(!bytes.is_empty());
+    }
+
+    #[test]
+    fn strict_conversions_fail_fractional_float_to_int() {
+        use crate::variant::args::VariantArgs;
+        use std::io::Write;
+
+        std::fs::create_dir_all("out").unwrap();
+
+        let layout_toml = r#"
+[settings]
+endianness = "little"
+virtual_offset = 0
+byte_swap = false
+pad_to_end = false
+
+[settings.crc]
+polynomial = 0x04C11DB7
+start = 0xFFFFFFFF
+xor_out = 0xFFFFFFFF
+ref_in = true
+ref_out = true
+
+[block.header]
+start_address = 0x80000
+length = 0x100
+crc_location = "end"
+padding = 0x00
+
+[block.data]
+bad.frac_to_u8 = { value = 1.5, type = "u8" }
+"#;
+
+        let path = Path::new("out").join("test_strict_bad_frac.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(layout_toml.as_bytes()).unwrap();
+
+        let cfg = crate::layout::load_layout(path.to_str().unwrap()).expect("parse bad layout");
+        let block = cfg.blocks.get("block").expect("block present");
+
+        let var_args = VariantArgs {
+            xlsx: "examples/data.xlsx".to_string(),
+            variant: None,
+            debug: false,
+            main_sheet: "Main".to_string(),
+        };
+        let ds = DataSheet::new(&var_args).expect("datasheet loads");
+
+        let res = block.build_bytestream(&ds, &cfg.settings, true);
+        assert!(res.is_err(), "strict mode should reject fractional float to int");
+    }
+
+    #[test]
+    fn strict_conversions_fail_large_int_to_f64_lossy() {
+        use crate::variant::args::VariantArgs;
+        use std::io::Write;
+
+        std::fs::create_dir_all("out").unwrap();
+
+        // 2^53 + 1 is not exactly representable in f64
+        let layout_toml = r#"
+[settings]
+endianness = "little"
+virtual_offset = 0
+byte_swap = false
+pad_to_end = false
+
+[settings.crc]
+polynomial = 0x04C11DB7
+start = 0xFFFFFFFF
+xor_out = 0xFFFFFFFF
+ref_in = true
+ref_out = true
+
+[block.header]
+start_address = 0x80000
+length = 0x100
+crc_location = "end"
+padding = 0x00
+
+[block.data]
+bad.large_int_to_f64 = { value = 9007199254740993, type = "f64" }
+"#;
+
+        let path = Path::new("out").join("test_strict_bad_large.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(layout_toml.as_bytes()).unwrap();
+
+        let cfg = crate::layout::load_layout(path.to_str().unwrap()).expect("parse bad layout");
+        let block = cfg.blocks.get("block").expect("block present");
+
+        let var_args = VariantArgs {
+            xlsx: "examples/data.xlsx".to_string(),
+            variant: None,
+            debug: false,
+            main_sheet: "Main".to_string(),
+        };
+        let ds = DataSheet::new(&var_args).expect("datasheet loads");
+
+        let res = block.build_bytestream(&ds, &cfg.settings, true);
+        assert!(res.is_err(), "strict mode should reject lossy int to f64 conversion");
+    }
 }


### PR DESCRIPTION
Add a `--strict` flag to enforce rigorous type conversions during bytestream assembly, preventing silent data loss.

This PR introduces a `strict` flag that, when enabled, disallows lossy type conversions (e.g., float to integer with fractional parts, out-of-range integer conversions, or lossy float narrowing) during the bytestream generation process. This ensures data integrity by explicitly failing on conversions that would otherwise silently alter data.

---
Linear Issue: [LIN-16](https://linear.app/tomfordpersonal/issue/LIN-16/add-strict-flag)

<a href="https://cursor.com/background-agent?bcId=bc-cf028b93-049d-43cb-9bd9-2b6e8a611ff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf028b93-049d-43cb-9bd9-2b6e8a611ff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

