### PR TITLE
Refactor code into new modules

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1,0 +1,32 @@
+use crate::args::Args;
+use crate::error::NvmError;
+use crate::layout;
+use crate::layout::args::BlockNames;
+use crate::variant::DataSheet;
+use crate::writer::write_output;
+
+pub fn build_block_single(input: &BlockNames, data_sheet: &DataSheet, args: &Args) -> Result<(), NvmError> {
+	let layout = layout::load_layout(&input.file)?;
+
+	let block = layout
+		.blocks
+		.get(&input.name)
+		.ok_or(NvmError::BlockNotFound(input.name.clone()))?;
+
+	let mut bytestream = block.build_bytestream(data_sheet, &layout.settings)?;
+
+	let hex_string = crate::output::bytestream_to_hex_string(
+		&mut bytestream,
+		&block.header,
+		&layout.settings,
+		layout.settings.byte_swap,
+		args.output.record_width as usize,
+		layout.settings.pad_to_end,
+		args.output.format,
+	)?;
+
+	write_output(&args.output, &input.name, &hex_string)?;
+
+	Ok(())
+}
+

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,14 +3,11 @@ pub mod generate;
 use crate::args::Args;
 use crate::error::NvmError;
 use crate::variant::DataSheet;
+use rayon::prelude::*;
 
 pub fn build_separate_blocks(args: &Args, data_sheet: &DataSheet) -> Result<(), NvmError> {
-	use rayon::prelude::*;
-
-	args
-		.layout
-		.blocks
-		.par_iter()
-		.try_for_each(|input| generate::build_block_single(input, data_sheet, args))
+    args.layout
+        .blocks
+        .par_iter()
+        .try_for_each(|input| generate::build_block_single(input, data_sheet, args))
 }
-

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,16 @@
+pub mod generate;
+
+use crate::args::Args;
+use crate::error::NvmError;
+use crate::variant::DataSheet;
+
+pub fn build_separate_blocks(args: &Args, data_sheet: &DataSheet) -> Result<(), NvmError> {
+	use rayon::prelude::*;
+
+	args
+		.layout
+		.blocks
+		.par_iter()
+		.try_for_each(|input| generate::build_block_single(input, data_sheet, args))
+}
+

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,0 +1,26 @@
+use std::path::Path;
+
+use crate::error::NvmError;
+use crate::output::args::{OutputArgs, OutputFormat};
+
+pub fn write_output(args: &OutputArgs, block_name: &str, contents: &str) -> Result<(), NvmError> {
+    let mut name_parts: Vec<String> = Vec::new();
+    if !args.prefix.is_empty() {
+        name_parts.push(args.prefix.clone());
+    }
+    name_parts.push(block_name.to_string());
+    if !args.suffix.is_empty() {
+        name_parts.push(args.suffix.clone());
+    }
+    let ext = match args.format {
+        OutputFormat::Hex => "hex",
+        OutputFormat::Mot => "mot",
+    };
+    let out_filename = format!("{}.{}", name_parts.join("_"), ext);
+    let out_path = Path::new(&args.out).join(out_filename);
+    std::fs::write(out_path, contents).map_err(|e| {
+        NvmError::FileError(format!("failed to write block {}: {}", block_name, e))
+    })?;
+    Ok(())
+}
+


### PR DESCRIPTION
Refactor block generation and output logic into new `commands` and `writer` modules to prepare for multi-block combined output support.

---
Linear Issue: [LIN-22](https://linear.app/tomfordpersonal/issue/LIN-22/add-multi-block-combined-output-support)

<a href="https://cursor.com/background-agent?bcId=bc-6ff3bcb0-ac82-4f0f-a627-d1f8d9075db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6ff3bcb0-ac82-4f0f-a627-d1f8d9075db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

