### PR TITLE
Update crc settings for memory range

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ Nvmbuilder is an embedded development tool that works with layout files (toml/ya
 
 ## Tools
 
+The development environment uses Nix. You may have to run cargo commands via nix develop.
+
 Always run `cargo test` as a final check after making any changes.
 
 Remember to use formatting tools to clean up your code once finished.

--- a/examples/block.json
+++ b/examples/block.json
@@ -9,7 +9,8 @@
             "start": 4294967295,
             "xor_out": 4294967295,
             "ref_in": true,
-            "ref_out": true
+            "ref_out": true,
+            "area": "data"
         }
     },
     "block": {

--- a/examples/block.toml
+++ b/examples/block.toml
@@ -10,6 +10,7 @@ start = 0xFFFFFFFF
 xor_out = 0xFFFFFFFF
 ref_in = true
 ref_out = true
+area = "data"
 
 [block.header]
 start_address = 0x8B000

--- a/examples/block.yaml
+++ b/examples/block.yaml
@@ -9,6 +9,7 @@ settings:
     xor_out: 0xFFFFFFFF
     ref_in: true
     ref_out: true
+    area: "data"
 
 block:
   header:

--- a/src/layout/settings.rs
+++ b/src/layout/settings.rs
@@ -19,6 +19,14 @@ pub enum Endianness {
     Big,
 }
 
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum CrcArea {
+    #[serde(rename = "data")]
+    Data,
+    #[serde(rename = "block")]
+    Block,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct CrcData {
     pub polynomial: u32,
@@ -26,6 +34,7 @@ pub struct CrcData {
     pub xor_out: u32,
     pub ref_in: bool,
     pub ref_out: bool,
+    pub area: CrcArea,
 }
 
 fn default_offset() -> u32 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 use clap::Parser;
 
 use nvmbuilder::args::Args;
+use nvmbuilder::commands;
 use nvmbuilder::error::*;
 use nvmbuilder::layout;
 use nvmbuilder::output;
 use nvmbuilder::variant::DataSheet;
-use nvmbuilder::commands;
 
 fn main() -> Result<(), NvmError> {
     let args = Args::parse();

--- a/tests/mixed_features.rs
+++ b/tests/mixed_features.rs
@@ -32,6 +32,7 @@ start = 0xFFFFFFFF
 xor_out = 0xFFFFFFFF
 ref_in = true
 ref_out = true
+area = "data"
 
 [block.header]
 start_address = 0x10000
@@ -58,6 +59,7 @@ start = 0xFFFFFFFF
 xor_out = 0xFFFFFFFF
 ref_in = true
 ref_out = true
+area = "data"
 
 [block.header]
 start_address = 0x90000
@@ -90,7 +92,10 @@ arr2.i16 = { value = [10, -20, 30, -40], type = "i16", size = 4 }
     // Case 1: Big endian, swap, pad to end, CRC at explicit address, HEX with width 64
     let args_be_hex = nvmbuilder::args::Args {
         layout: nvmbuilder::layout::args::LayoutArgs {
-            blocks: vec![BlockNames { name: "block".to_string(), file: be_path.clone() }],
+            blocks: vec![BlockNames {
+                name: "block".to_string(),
+                file: be_path.clone(),
+            }],
             strict: false,
         },
         variant: var_args.clone(),
@@ -102,13 +107,24 @@ arr2.i16 = { value = [10, -20, 30, -40], type = "i16", size = 4 }
             format: OutputFormat::Hex,
         },
     };
-    build_block_single(&BlockNames { name: "block".to_string(), file: be_path.clone() }, &ds, &args_be_hex).expect("be-hex");
+    build_block_single(
+        &BlockNames {
+            name: "block".to_string(),
+            file: be_path.clone(),
+        },
+        &ds,
+        &args_be_hex,
+    )
+    .expect("be-hex");
     assert!(std::path::Path::new("out/MIX_block_A.hex").exists());
 
     // Case 2: Big endian, swap, pad to end, explicit CRC, MOT with width 16
     let args_be_mot = nvmbuilder::args::Args {
         layout: nvmbuilder::layout::args::LayoutArgs {
-            blocks: vec![BlockNames { name: "block".to_string(), file: be_path.clone() }],
+            blocks: vec![BlockNames {
+                name: "block".to_string(),
+                file: be_path.clone(),
+            }],
             strict: false,
         },
         variant: var_args.clone(),
@@ -120,13 +136,24 @@ arr2.i16 = { value = [10, -20, 30, -40], type = "i16", size = 4 }
             format: OutputFormat::Mot,
         },
     };
-    build_block_single(&BlockNames { name: "block".to_string(), file: be_path.clone() }, &ds, &args_be_mot).expect("be-mot");
+    build_block_single(
+        &BlockNames {
+            name: "block".to_string(),
+            file: be_path.clone(),
+        },
+        &ds,
+        &args_be_mot,
+    )
+    .expect("be-mot");
     assert!(std::path::Path::new("out/MIX_block_B.mot").exists());
 
     // Case 3: Little endian, no swap, no pad to end, CRC at end, HEX width 16, virtual_offset applied
     let args_le_hex = nvmbuilder::args::Args {
         layout: nvmbuilder::layout::args::LayoutArgs {
-            blocks: vec![BlockNames { name: "block".to_string(), file: le_path.clone() }],
+            blocks: vec![BlockNames {
+                name: "block".to_string(),
+                file: le_path.clone(),
+            }],
             strict: true, // exercise strict path on numeric arrays
         },
         variant: var_args.clone(),
@@ -138,13 +165,24 @@ arr2.i16 = { value = [10, -20, 30, -40], type = "i16", size = 4 }
             format: OutputFormat::Hex,
         },
     };
-    build_block_single(&BlockNames { name: "block".to_string(), file: le_path.clone() }, &ds, &args_le_hex).expect("le-hex");
+    build_block_single(
+        &BlockNames {
+            name: "block".to_string(),
+            file: le_path.clone(),
+        },
+        &ds,
+        &args_le_hex,
+    )
+    .expect("le-hex");
     assert!(std::path::Path::new("out/MIX_block_C.hex").exists());
 
     // Case 4: Little endian, no swap, no pad, CRC at end, MOT width 64
     let args_le_mot = nvmbuilder::args::Args {
         layout: nvmbuilder::layout::args::LayoutArgs {
-            blocks: vec![BlockNames { name: "block".to_string(), file: le_path.clone() }],
+            blocks: vec![BlockNames {
+                name: "block".to_string(),
+                file: le_path.clone(),
+            }],
             strict: true,
         },
         variant: var_args,
@@ -156,7 +194,14 @@ arr2.i16 = { value = [10, -20, 30, -40], type = "i16", size = 4 }
             format: OutputFormat::Mot,
         },
     };
-    build_block_single(&BlockNames { name: "block".to_string(), file: le_path.clone() }, &ds, &args_le_mot).expect("le-mot");
+    build_block_single(
+        &BlockNames {
+            name: "block".to_string(),
+            file: le_path.clone(),
+        },
+        &ds,
+        &args_le_mot,
+    )
+    .expect("le-mot");
     assert!(std::path::Path::new("out/MIX_block_D.mot").exists());
 }
-

--- a/tests/strict_conversions.rs
+++ b/tests/strict_conversions.rs
@@ -20,6 +20,7 @@ start = 0xFFFFFFFF
 xor_out = 0xFFFFFFFF
 ref_in = true
 ref_out = true
+area = "data"
 
 [block.header]
 start_address = 0x80000
@@ -70,6 +71,7 @@ start = 0xFFFFFFFF
 xor_out = 0xFFFFFFFF
 ref_in = true
 ref_out = true
+area = "data"
 
 [block.header]
 start_address = 0x80000
@@ -97,7 +99,10 @@ bad.frac_to_u8 = { value = 1.5, type = "u8" }
     let ds = nvmbuilder::variant::DataSheet::new(&var_args).expect("datasheet loads");
 
     let res = block.build_bytestream(&ds, &cfg.settings, true);
-    assert!(res.is_err(), "strict mode should reject fractional float to int");
+    assert!(
+        res.is_err(),
+        "strict mode should reject fractional float to int"
+    );
 }
 
 #[test]
@@ -117,6 +122,7 @@ start = 0xFFFFFFFF
 xor_out = 0xFFFFFFFF
 ref_in = true
 ref_out = true
+area = "data"
 
 [block.header]
 start_address = 0x80000
@@ -144,6 +150,8 @@ bad.large_int_to_f64 = { value = 9007199254740993, type = "f64" }
     let ds = nvmbuilder::variant::DataSheet::new(&var_args).expect("datasheet loads");
 
     let res = block.build_bytestream(&ds, &cfg.settings, true);
-    assert!(res.is_err(), "strict mode should reject lossy int to f64 conversion");
+    assert!(
+        res.is_err(),
+        "strict mode should reject lossy int to f64 conversion"
+    );
 }
-


### PR DESCRIPTION
Add `area` setting to CRC configuration to allow specifying CRC calculation over either the data payload or the entire padded block.

---
Linear Issue: [LIN-35](https://linear.app/tomfordpersonal/issue/LIN-35/layout-crc-options-should-just-define-a-memory-range-to-crc)

<a href="https://cursor.com/background-agent?bcId=bc-41b4ba6a-9330-4122-8336-aeb061298a91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-41b4ba6a-9330-4122-8336-aeb061298a91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

