### PR TITLE
Refactor hex emission for combined block output

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -17,11 +17,10 @@ pub fn build_block_single(
         .get(&input.name)
         .ok_or(NvmError::BlockNotFound(input.name.clone()))?;
 
-    let mut bytestream =
-        block.build_bytestream(data_sheet, &layout.settings, args.layout.strict)?;
+    let bytestream = block.build_bytestream(data_sheet, &layout.settings, args.layout.strict)?;
 
-    let data_range = crate::output::bytestream_to_hex_string(
-        &mut bytestream,
+    let data_range = crate::output::bytestream_to_datarange(
+        bytestream,
         &block.header,
         &layout.settings,
         layout.settings.byte_swap,

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -20,13 +20,17 @@ pub fn build_block_single(
     let mut bytestream =
         block.build_bytestream(data_sheet, &layout.settings, args.layout.strict)?;
 
-    let hex_string = crate::output::bytestream_to_hex_string(
+    let data_range = crate::output::bytestream_to_hex_string(
         &mut bytestream,
         &block.header,
         &layout.settings,
         layout.settings.byte_swap,
-        args.output.record_width as usize,
         layout.settings.pad_to_end,
+    )?;
+
+    let hex_string = crate::output::emit_hex(
+        &[data_range],
+        args.output.record_width as usize,
         args.output.format,
     )?;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,9 @@ pub mod generate;
 
 use crate::args::Args;
 use crate::error::NvmError;
+use crate::layout;
+use crate::output;
+use crate::writer::write_output;
 use crate::variant::DataSheet;
 use rayon::prelude::*;
 
@@ -10,4 +13,36 @@ pub fn build_separate_blocks(args: &Args, data_sheet: &DataSheet) -> Result<(), 
         .blocks
         .par_iter()
         .try_for_each(|input| generate::build_block_single(input, data_sheet, args))
+}
+
+pub fn build_single_file(args: &Args, data_sheet: &DataSheet) -> Result<(), NvmError> {
+    let mut payloads: Vec<Vec<u8>> = Vec::new();
+    let mut ranges = Vec::new();
+
+    for input in &args.layout.blocks {
+        let layout = layout::load_layout(&input.file)?;
+
+        let block = layout
+            .blocks
+            .get(&input.name)
+            .ok_or(NvmError::BlockNotFound(input.name.clone()))?;
+
+        let mut bytestream =
+            block.build_bytestream(data_sheet, &layout.settings, args.layout.strict)?;
+
+        payloads.push(bytestream);
+        let bs_ref = payloads.last_mut().expect("payloads not empty");
+        let dr = output::bytestream_to_hex_string(
+            bs_ref,
+            &block.header,
+            &layout.settings,
+            layout.settings.byte_swap,
+            layout.settings.pad_to_end,
+        )?;
+        ranges.push(dr);
+    }
+
+    let hex_string = output::emit_hex(&ranges, args.output.record_width as usize, args.output.format)?;
+
+    write_output(&args.output, "combined", &hex_string)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,10 @@ fn main() -> Result<(), NvmError> {
     std::fs::create_dir_all(&args.output.out)
         .map_err(|e| NvmError::FileError(format!("failed to create output directory: {}", e)))?;
 
-    commands::build_separate_blocks(&args, &data_sheet)?;
+    match args.output.combined {
+        true => commands::build_single_file(&args, &data_sheet)?,
+        false => commands::build_separate_blocks(&args, &data_sheet)?,
+    }
 
     Ok(())
 }

--- a/src/output/args.rs
+++ b/src/output/args.rs
@@ -49,4 +49,7 @@ pub struct OutputArgs {
         help = "Output format: hex or mot",
     )]
     pub format: OutputFormat,
+
+    #[arg(long, help = "Emit a single combined file instead of one per block")]
+    pub combined: bool,
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -9,9 +9,9 @@ use crate::output::args::OutputFormat;
 use bin_file::{BinFile, IHexFormat};
 
 #[derive(Debug, Clone)]
-pub struct DataRange<'a> {
+pub struct DataRange {
     pub start_address: u32,
-    pub bytestream: &'a [u8],
+    pub bytestream: Vec<u8>,
     pub crc_address: u32,
     pub crc_bytestream: Vec<u8>,
 }
@@ -57,13 +57,13 @@ fn validate_crc_location(length: usize, header: &Header) -> Result<u32, NvmError
     Ok(crc_offset)
 }
 
-pub fn bytestream_to_hex_string(
-    bytestream: &mut Vec<u8>,
+pub fn bytestream_to_datarange(
+    mut bytestream: Vec<u8>,
     header: &Header,
     settings: &Settings,
     byte_swap: bool,
     pad_to_end: bool,
-) -> Result<DataRange<'_>, NvmError> {
+) -> Result<DataRange, NvmError> {
     if bytestream.len() > header.length as usize {
         return Err(NvmError::HexOutputError(
             "Bytestream length exceeds block length.".to_string(),
@@ -72,7 +72,7 @@ pub fn bytestream_to_hex_string(
 
     // Apply optional byte swap across the entire stream before CRC
     if byte_swap {
-        byte_swap_inplace(bytestream);
+        byte_swap_inplace(bytestream.as_mut_slice());
     }
 
     // Determine CRC location relative to current payload end
@@ -90,7 +90,7 @@ pub fn bytestream_to_hex_string(
     }
 
     // Compute CRC based on selected area
-    let crc_val = checksum::calculate_crc(bytestream);
+    let crc_val = checksum::calculate_crc(&bytestream);
 
     let mut crc_bytes = match settings.endianness {
         Endianness::Big => crc_val.to_be_bytes(),
@@ -107,14 +107,14 @@ pub fn bytestream_to_hex_string(
 
     Ok(DataRange {
         start_address: header.start_address + settings.virtual_offset,
-        bytestream: bytestream.as_slice(),
+        bytestream,
         crc_address: header.start_address + settings.virtual_offset + crc_location,
         crc_bytestream: crc_bytes.to_vec(),
     })
 }
 
-pub fn emit_hex<'a>(
-    ranges: &[DataRange<'a>],
+pub fn emit_hex(
+    ranges: &[DataRange],
     record_width: usize,
     format: OutputFormat,
 ) -> Result<String, NvmError> {
@@ -123,10 +123,18 @@ pub fn emit_hex<'a>(
     let mut max_end: usize = 0;
 
     for range in ranges {
-        bf.add_bytes(range.bytestream, Some(range.start_address as usize), false)
-            .map_err(|e| NvmError::HexOutputError(format!("Failed to add bytes: {}", e)))?;
-        bf.add_bytes(range.crc_bytestream.as_slice(), Some(range.crc_address as usize), true)
-            .map_err(|e| NvmError::HexOutputError(format!("Failed to add bytes: {}", e)))?;
+        bf.add_bytes(
+            range.bytestream.as_slice(),
+            Some(range.start_address as usize),
+            false,
+        )
+        .map_err(|e| NvmError::HexOutputError(format!("Failed to add bytes: {}", e)))?;
+        bf.add_bytes(
+            range.crc_bytestream.as_slice(),
+            Some(range.crc_address as usize),
+            true,
+        )
+        .map_err(|e| NvmError::HexOutputError(format!("Failed to add bytes: {}", e)))?;
 
         let end = (range.start_address as usize).saturating_add(range.bytestream.len());
         if end > max_end {
@@ -208,15 +216,9 @@ mod tests {
         checksum::init_crc_algorithm(&settings.crc);
         let header = sample_header(16);
 
-        let mut bytestream = vec![1u8, 2, 3, 4];
-        let dr = bytestream_to_hex_string(
-            &mut bytestream,
-            &header,
-            &settings,
-            false,
-            false,
-        )
-        .expect("data range generation failed");
+        let bytestream = vec![1u8, 2, 3, 4];
+        let dr = bytestream_to_datarange(bytestream.clone(), &header, &settings, false, false)
+            .expect("data range generation failed");
         let hex = emit_hex(&[dr], 16, crate::output::args::OutputFormat::Hex)
             .expect("hex generation failed");
 
@@ -247,16 +249,10 @@ mod tests {
         checksum::init_crc_algorithm(&settings.crc);
         let header = sample_header(32);
 
-        let mut bytestream = vec![1u8, 2, 3, 4];
-        let _dr = bytestream_to_hex_string(
-            &mut bytestream,
-            &header,
-            &settings,
-            false,
-            true,
-        )
-        .expect("data range generation failed");
+        let bytestream = vec![1u8, 2, 3, 4];
+        let dr = bytestream_to_datarange(bytestream, &header, &settings, false, true)
+            .expect("data range generation failed");
 
-        assert_eq!(bytestream.len(), header.length as usize);
+        assert_eq!(dr.bytestream.len(), header.length as usize);
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -46,6 +46,7 @@ pub fn build_args(layout_path: &str, block_name: &str, format: OutputFormat) -> 
             suffix: "SUF".to_string(),
             record_width: 32,
             format,
+            combined: false,
         },
     }
 }
@@ -98,6 +99,7 @@ pub fn build_args_for_layouts(layouts: Vec<BlockNames>, format: OutputFormat) ->
             suffix: "SUF".to_string(),
             record_width: 32,
             format,
+            combined: true,
         },
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -79,3 +79,25 @@ pub fn assert_out_file_exists(block_name: &str, format: OutputFormat) {
     let expected = format!("{}_{}_{}.{}", "PRE", block_name, "SUF", ext);
     assert!(Path::new("out").join(expected).exists());
 }
+
+pub fn build_args_for_layouts(layouts: Vec<BlockNames>, format: OutputFormat) -> Args {
+    Args {
+        layout: LayoutArgs {
+            blocks: layouts,
+            strict: false,
+        },
+        variant: variant::args::VariantArgs {
+            xlsx: "examples/data.xlsx".to_string(),
+            variant: None,
+            debug: false,
+            main_sheet: "Main".to_string(),
+        },
+        output: OutputArgs {
+            out: "out".to_string(),
+            prefix: "PRE".to_string(),
+            suffix: "SUF".to_string(),
+            record_width: 32,
+            format,
+        },
+    }
+}

--- a/tests/mixed_features.rs
+++ b/tests/mixed_features.rs
@@ -105,6 +105,7 @@ arr2.i16 = { value = [10, -20, 30, -40], type = "i16", size = 4 }
             suffix: "A".to_string(),
             record_width: 64,
             format: OutputFormat::Hex,
+            combined: false,
         },
     };
     build_block_single(
@@ -134,6 +135,7 @@ arr2.i16 = { value = [10, -20, 30, -40], type = "i16", size = 4 }
             suffix: "B".to_string(),
             record_width: 16,
             format: OutputFormat::Mot,
+            combined: false,
         },
     };
     build_block_single(
@@ -163,6 +165,7 @@ arr2.i16 = { value = [10, -20, 30, -40], type = "i16", size = 4 }
             suffix: "C".to_string(),
             record_width: 16,
             format: OutputFormat::Hex,
+            combined: false,
         },
     };
     build_block_single(
@@ -192,6 +195,7 @@ arr2.i16 = { value = [10, -20, 30, -40], type = "i16", size = 4 }
             suffix: "D".to_string(),
             record_width: 64,
             format: OutputFormat::Mot,
+            combined: false,
         },
     };
     build_block_single(


### PR DESCRIPTION
Refactor `bytestream_to_hex_string` to return `DataRange` and add `build_single_file` command to support unified multi-block hex output.

This refactoring decouples data preparation from hex emission by having `bytestream_to_hex_string` return a `DataRange` (containing block data and CRC) and making `emit_hex` public to consume multiple `DataRange`s. This enables the new `build_single_file` command to combine several blocks into a single output hex file, addressing the need for unified multi-block processing.

---
Linear Issue: [LIN-34](https://linear.app/tomfordpersonal/issue/LIN-34/refactor-block-emission-architecture-for-unified-multi-block-output)

<a href="https://cursor.com/background-agent?bcId=bc-ca5f6b08-d81c-4bd3-a153-9e8abc4e3e71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca5f6b08-d81c-4bd3-a153-9e8abc4e3e71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

