### PR TITLE
Implement overlap error for combined file build

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub fn build_separate_blocks(args: &Args, data_sheet: &DataSheet) -> Result<(), 
 
 pub fn build_single_file(args: &Args, data_sheet: &DataSheet) -> Result<(), NvmError> {
     let mut ranges = Vec::new();
+    let mut block_ranges: Vec<(String, u32, u32)> = Vec::new();
 
     for input in &args.layout.blocks {
         let layout = layout::load_layout(&input.file)?;
@@ -37,6 +38,38 @@ pub fn build_single_file(args: &Args, data_sheet: &DataSheet) -> Result<(), NvmE
             layout.settings.pad_to_end,
         )?;
         ranges.push(dr);
+
+        let start = block.header.start_address + layout.settings.virtual_offset;
+        let end = start + block.header.length;
+        block_ranges.push((input.name.clone(), start, end));
+    }
+
+    // Detect overlaps between declared block memory ranges (inclusive start, exclusive end)
+    for i in 0..block_ranges.len() {
+        for j in (i + 1)..block_ranges.len() {
+            let (ref name_a, a_start, a_end) = block_ranges[i];
+            let (ref name_b, b_start, b_end) = block_ranges[j];
+
+            let overlap_start = a_start.max(b_start);
+            let overlap_end = a_end.min(b_end);
+
+            if overlap_start < overlap_end {
+                let overlap_size = overlap_end - overlap_start;
+                let msg = format!(
+                    "Block '{}' (0x{:08X}-0x{:08X}) overlaps with block '{}' (0x{:08X}-0x{:08X}). Overlap: 0x{:08X}-0x{:08X} ({} bytes)",
+                    name_a,
+                    a_start,
+                    a_end - 1,
+                    name_b,
+                    b_start,
+                    b_end - 1,
+                    overlap_start,
+                    overlap_end - 1,
+                    overlap_size
+                );
+                return Err(NvmError::BlockOverlapError(msg));
+            }
+        }
     }
 
     let hex_string = output::emit_hex(

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,4 +34,7 @@ pub enum NvmError {
 
     #[error("Hex output error: {0}.")]
     HexOutputError(String),
+
+    #[error("Block memory overlap detected: {0}")]
+    BlockOverlapError(String),
 }


### PR DESCRIPTION
Add block overlap detection for combined hex files to prevent data conflicts.

---
Linear Issue: [LIN-36](https://linear.app/tomfordpersonal/issue/LIN-36/add-block-overlap-detection-with-context-sensitive-errorwarning)

<a href="https://cursor.com/background-agent?bcId=bc-6b2fdc1b-4bf3-4c42-9047-81334ad6873c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6b2fdc1b-4bf3-4c42-9047-81334ad6873c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

