### PR TITLE
Adjust padding usage in stats

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -19,7 +19,7 @@ pub fn build_block_single(
         .get(&input.name)
         .ok_or(NvmError::BlockNotFound(input.name.clone()))?;
 
-    let bytestream = block.build_bytestream(data_sheet, &layout.settings, args.layout.strict)?;
+    let (bytestream, padding_bytes) = block.build_bytestream(data_sheet, &layout.settings, args.layout.strict)?;
 
     let data_range = crate::output::bytestream_to_datarange(
         bytestream,
@@ -27,6 +27,7 @@ pub fn build_block_single(
         &layout.settings,
         layout.settings.byte_swap,
         layout.settings.pad_to_end,
+        padding_bytes,
     )?;
 
     let hex_string = crate::output::emit_hex(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -47,7 +47,7 @@ pub fn build_single_file(args: &Args, data_sheet: &DataSheet) -> Result<BuildSta
             .get(&input.name)
             .ok_or(NvmError::BlockNotFound(input.name.clone()))?;
 
-        let bytestream =
+        let (bytestream, padding_bytes) =
             block.build_bytestream(data_sheet, &layout.settings, args.layout.strict)?;
 
         let dr = output::bytestream_to_datarange(
@@ -56,6 +56,7 @@ pub fn build_single_file(args: &Args, data_sheet: &DataSheet) -> Result<BuildSta
             &layout.settings,
             layout.settings.byte_swap,
             layout.settings.pad_to_end,
+            padding_bytes,
         )?;
 
         let crc_value = match layout.settings.endianness {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -65,6 +65,7 @@ pub fn bytestream_to_datarange(
     settings: &Settings,
     byte_swap: bool,
     pad_to_end: bool,
+    padding_bytes: u32,
 ) -> Result<DataRange, NvmError> {
     if bytestream.len() > header.length as usize {
         return Err(NvmError::HexOutputError(
@@ -80,7 +81,7 @@ pub fn bytestream_to_datarange(
     // Determine CRC location relative to current payload end
     let crc_location = validate_crc_location(bytestream.len(), header)?;
 
-    let used_size = (bytestream.len() + 4) as u32;
+    let used_size = (bytestream.len() + 4) as u32 - padding_bytes;
     let allocated_size = header.length;
 
     // Padding for CRC alignment
@@ -224,7 +225,7 @@ mod tests {
         let header = sample_header(16);
 
         let bytestream = vec![1u8, 2, 3, 4];
-        let dr = bytestream_to_datarange(bytestream.clone(), &header, &settings, false, false)
+        let dr = bytestream_to_datarange(bytestream.clone(), &header, &settings, false, false, 0)
             .expect("data range generation failed");
         let hex = emit_hex(&[dr], 16, crate::output::args::OutputFormat::Hex)
             .expect("hex generation failed");
@@ -257,7 +258,7 @@ mod tests {
         let header = sample_header(32);
 
         let bytestream = vec![1u8, 2, 3, 4];
-        let dr = bytestream_to_datarange(bytestream, &header, &settings, false, true)
+        let dr = bytestream_to_datarange(bytestream, &header, &settings, false, true, 0)
             .expect("data range generation failed");
 
         assert_eq!(dr.bytestream.len(), header.length as usize);

--- a/tests/strict_conversions.rs
+++ b/tests/strict_conversions.rs
@@ -48,7 +48,7 @@ ok.int_exact_to_f32   = { value = 16777216, type = "f32" }
     };
     let ds = nvmbuilder::variant::DataSheet::new(&var_args).expect("datasheet loads");
 
-    let bytes = block
+    let (bytes, _padding) = block
         .build_bytestream(&ds, &cfg.settings, true)
         .expect("strict conversions should succeed");
     assert!(!bytes.is_empty());


### PR DESCRIPTION
Track and subtract alignment padding from `used_size` in stats to provide a more accurate measure of space efficiency.

---
Linear Issue: [LIN-38](https://linear.app/tomfordpersonal/issue/LIN-38/track-padding-usage-in-stats)

<a href="https://cursor.com/background-agent?bcId=bc-cd571e6d-e66e-4895-8792-b640b3bf8718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cd571e6d-e66e-4895-8792-b640b3bf8718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

